### PR TITLE
 switch/select type dynamically 

### DIFF
--- a/dist/angular-local-storage.js
+++ b/dist/angular-local-storage.js
@@ -118,7 +118,7 @@ angular
       }
       
       // Checks the browser to see if local storage is supported
-      var browserSupportsLocalStorage = (function () {
+      var checkSupport = function () {
         try {
           var supported = (storageType in $window && $window[storageType] !== null);
 
@@ -142,12 +142,17 @@ angular
           $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
           return false;
         }
-      }());
+      };
+      var browserSupportsLocalStorage = checkSupport();
 
       // Directly adds a value to local storage
       // If local storage is not available in the browser use cookies
       // Example use: localStorageService.add('library','angular');
-      var addToLocalStorage = function (key, value) {
+      var addToLocalStorage = function (key, value, type) {
+        if (type) {
+          setStorageType(type);
+        }
+        
         // Let's convert undefined values to null to get the value consistent
         if (isUndefined(value)) {
           value = null;
@@ -156,7 +161,7 @@ angular
         }
 
         // If this browser does not support local storage use cookies
-        if (!browserSupportsLocalStorage  && self.defaultToCookie  || self.storageType === 'cookie') {
+        if (!browserSupportsLocalStorage && self.defaultToCookie || self.storageType === 'cookie') {
           if (!browserSupportsLocalStorage) {
             $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
           }
@@ -183,7 +188,10 @@ angular
 
       // Directly get a value from local storage
       // Example use: localStorageService.get('library'); // returns 'angular'
-      var getFromLocalStorage = function (key) {
+      var getFromLocalStorage = function (key, type) {
+        if (type) {
+          setStorageType(type);
+        }
 
         if (!browserSupportsLocalStorage && self.defaultToCookie  || self.storageType === 'cookie') {
           if (!browserSupportsLocalStorage) {
@@ -209,6 +217,10 @@ angular
 
       // Remove an item from local storage
       // Example use: localStorageService.remove('library'); // removes the key/value pair of library='angular'
+      //
+      // TODO: This is var-arg removal, need to check the last (or first) argument to see if it is a storageType
+      //       and act accordingly. For now you can use setStorageType as a workaround to pick type first.
+      //
       var removeFromLocalStorage = function () {
         var i, key;
         for (i=0; i<arguments.length; i++) {
@@ -242,8 +254,11 @@ angular
 
       // Return array of keys for local storage
       // Example use: var keys = localStorageService.keys()
-      var getKeysForLocalStorage = function () {
-
+      var getKeysForLocalStorage = function (type) {
+        if (type) {
+          setStorageType(type);
+        }
+        
         if (!browserSupportsLocalStorage) {
           $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
           return [];
@@ -269,7 +284,10 @@ angular
       // Also optionally takes a regular expression string and removes the matching key-value pairs
       // Example use: localStorageService.clearAll();
       // Should be used mostly for development purposes
-      var clearAllFromLocalStorage = function (regularExpression) {
+      var clearAllFromLocalStorage = function (regularExpression, type) {
+        if (type) {
+          setStorageType(type);
+        }
 
         // Setting both regular expressions independently
         // Empty strings result in catchall RegExp
@@ -409,11 +427,16 @@ angular
           return storageType;
         };
 
+        var setStorageType = function(type) {
+          storageType = type;
+          browserSupportsLocalStorage = checkSupport();
+        };
+        
         // Add a listener on scope variable to save its changes to local storage
         // Return a function which when called cancels binding
-        var bindToScope = function(scope, key, def, lsKey) {
+        var bindToScope = function(scope, key, def, lsKey, type) {
           lsKey = lsKey || key;
-          var value = getFromLocalStorage(lsKey);
+          var value = getFromLocalStorage(lsKey, type);
 
           if (value === null && isDefined(def)) {
             value = def;
@@ -424,7 +447,7 @@ angular
           $parse(key).assign(scope, value);
 
           return scope.$watch(key, function(newVal) {
-            addToLocalStorage(lsKey, newVal);
+            addToLocalStorage(lsKey, newVal, type);
           }, isObject(scope[key]));
         };
 
@@ -453,7 +476,11 @@ angular
 
         // Return localStorageService.length
         // ignore keys that not owned
-        var lengthOfLocalStorage = function() {
+        var lengthOfLocalStorage = function(type) {
+          if (type) {
+            setStorageType(type);
+          }
+        
           var count = 0;
           var storage = $window[storageType];
           for(var i = 0; i < storage.length; i++) {
@@ -467,6 +494,7 @@ angular
         return {
           isSupported: browserSupportsLocalStorage,
           getStorageType: getStorageType,
+          setStorageType: setStorageType,
           set: addToLocalStorage,
           add: addToLocalStorage, //DEPRECATED
           get: getFromLocalStorage,


### PR DESCRIPTION
1) added setStorageType(type)
2) added type to relevant calls except removeFromLocalStorage(...), as it's a vararg variety, but easy to do if needed.

This is a non-intrusive patch, as it preserves original functionality, but adds storage type selectability when needed.

Typical use case:
  your existing code picked one type as default, but in a couple of places you need to use the other type, then try this:

  setStorageType(non-default-type);     // switch to new type
  ...do your storage calls
  setStorageType(default-type);            // restore default

Or you can specify a type to each call directly (without type specified, whatever the last type of any call will be used).
